### PR TITLE
chore(maven): remove jboss public repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,23 +83,6 @@
 		</dependencies>
 	</dependencyManagement>
 
-	<repositories>
-		<repository>
-			<id>jboss-public-repository-group</id>
-			<name>JBoss Public Maven Repository Group</name>
-			<url>https://repository.jboss.org/nexus/content/groups/public/</url>
-			<layout>default</layout>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>never</updatePolicy>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-				<updatePolicy>never</updatePolicy>
-			</snapshots>
-		</repository>
-	</repositories>
-
 	<build>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION
This repository is not needed, all artifacts are available on maven central